### PR TITLE
feat: add spotless formatter

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -172,7 +172,7 @@ publishing {
 
 spotless {
     // optional: limit format enforcement to just the files changed by this feature branch
-    ratchetFrom 'origin/main'
+    ratchetFrom 'origin/devel'
 
     format 'misc', {
         // define the files to apply `misc` to

--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,7 @@ plugins {
     id 'idea'
     id 'maven-publish'
     id 'net.neoforged.gradle.userdev' version '7.0.170'
+    id 'com.diffplug.spotless' version '7.0.3'
 }
 
 tasks.named('wrapper', Wrapper).configure {
@@ -166,6 +167,33 @@ publishing {
         maven {
             url "file://${project.projectDir}/repo"
         }
+    }
+}
+
+spotless {
+    // optional: limit format enforcement to just the files changed by this feature branch
+    ratchetFrom 'origin/main'
+
+    format 'misc', {
+        // define the files to apply `misc` to
+        target '*.gradle', '.gitattributes', '.gitignore'
+
+        // define the steps to apply to those files
+        trimTrailingWhitespace()
+        leadingTabsToSpaces() // or leadingTabsToSpaces. Takes an integer argument if you don't like 4
+        endWithNewline()
+    }
+    java {
+        // don't need to set target, it is inferred from java
+
+        // apply a specific flavor of google-java-format
+        googleJavaFormat('1.26.0').aosp().reflowLongStrings().skipJavadocFormatting()
+        // fix formatting of type annotations
+        formatAnnotations()
+        // make sure every file has the following copyright header.
+        // optionally, Spotless can set copyright years by digging
+        // through git history (see "license" section below)
+        licenseHeader '/* (C)$YEAR */'
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -187,7 +187,7 @@ spotless {
         // don't need to set target, it is inferred from java
 
         // apply a specific flavor of google-java-format
-        googleJavaFormat('1.26.0').aosp().reflowLongStrings().skipJavadocFormatting()
+        googleJavaFormat('1.26.0').reflowLongStrings().skipJavadocFormatting()
         // fix formatting of type annotations
         formatAnnotations()
         // make sure every file has the following copyright header.

--- a/src/main/java/com/example/examplemod/Config.java
+++ b/src/main/java/com/example/examplemod/Config.java
@@ -1,9 +1,9 @@
+/* (C)2025 */
 package com.example.examplemod;
 
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
-
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.Item;
@@ -12,29 +12,30 @@ import net.neoforged.fml.common.EventBusSubscriber;
 import net.neoforged.fml.event.config.ModConfigEvent;
 import net.neoforged.neoforge.common.ModConfigSpec;
 
-// An example config class. This is not required, but it's a good idea to have one to keep your config organized.
+// An example config class. This is not required, but it's a good idea to have one to keep your
+// config organized.
 // Demonstrates how to use Neo's config APIs
 @EventBusSubscriber(modid = ExampleMod.MODID, bus = EventBusSubscriber.Bus.MOD)
-public class Config
-{
+public class Config {
     private static final ModConfigSpec.Builder BUILDER = new ModConfigSpec.Builder();
 
-    private static final ModConfigSpec.BooleanValue LOG_DIRT_BLOCK = BUILDER
-            .comment("Whether to log the dirt block on common setup")
-            .define("logDirtBlock", true);
+    private static final ModConfigSpec.BooleanValue LOG_DIRT_BLOCK =
+            BUILDER.comment("Whether to log the dirt block on common setup")
+                    .define("logDirtBlock", true);
 
-    private static final ModConfigSpec.IntValue MAGIC_NUMBER = BUILDER
-            .comment("A magic number")
-            .defineInRange("magicNumber", 42, 0, Integer.MAX_VALUE);
+    private static final ModConfigSpec.IntValue MAGIC_NUMBER =
+            BUILDER.comment("A magic number")
+                    .defineInRange("magicNumber", 42, 0, Integer.MAX_VALUE);
 
-    public static final ModConfigSpec.ConfigValue<String> MAGIC_NUMBER_INTRODUCTION = BUILDER
-            .comment("What you want the introduction message to be for the magic number")
-            .define("magicNumberIntroduction", "The magic number is... ");
+    public static final ModConfigSpec.ConfigValue<String> MAGIC_NUMBER_INTRODUCTION =
+            BUILDER.comment("What you want the introduction message to be for the magic number")
+                    .define("magicNumberIntroduction", "The magic number is... ");
 
     // a list of strings that are treated as resource locations for items
-    private static final ModConfigSpec.ConfigValue<List<? extends String>> ITEM_STRINGS = BUILDER
-            .comment("A list of items to log on common setup.")
-            .defineListAllowEmpty("items", List.of("minecraft:iron_ingot"), Config::validateItemName);
+    private static final ModConfigSpec.ConfigValue<List<? extends String>> ITEM_STRINGS =
+            BUILDER.comment("A list of items to log on common setup.")
+                    .defineListAllowEmpty(
+                            "items", List.of("minecraft:iron_ingot"), Config::validateItemName);
 
     static final ModConfigSpec SPEC = BUILDER.build();
 
@@ -43,21 +44,24 @@ public class Config
     public static String magicNumberIntroduction;
     public static Set<Item> items;
 
-    private static boolean validateItemName(final Object obj)
-    {
-        return obj instanceof String itemName && BuiltInRegistries.ITEM.containsKey(ResourceLocation.parse(itemName));
+    private static boolean validateItemName(final Object obj) {
+        return obj instanceof String itemName
+                && BuiltInRegistries.ITEM.containsKey(ResourceLocation.parse(itemName));
     }
 
     @SubscribeEvent
-    static void onLoad(final ModConfigEvent event)
-    {
+    static void onLoad(final ModConfigEvent event) {
         logDirtBlock = LOG_DIRT_BLOCK.get();
         magicNumber = MAGIC_NUMBER.get();
         magicNumberIntroduction = MAGIC_NUMBER_INTRODUCTION.get();
 
         // convert the list of strings into a set of items
-        items = ITEM_STRINGS.get().stream()
-                .map(itemName -> BuiltInRegistries.ITEM.get(ResourceLocation.parse(itemName)))
-                .collect(Collectors.toSet());
+        items =
+                ITEM_STRINGS.get().stream()
+                        .map(
+                                itemName ->
+                                        BuiltInRegistries.ITEM.get(
+                                                ResourceLocation.parse(itemName)))
+                        .collect(Collectors.toSet());
     }
 }

--- a/src/main/java/com/example/examplemod/Config.java
+++ b/src/main/java/com/example/examplemod/Config.java
@@ -17,51 +17,47 @@ import net.neoforged.neoforge.common.ModConfigSpec;
 // Demonstrates how to use Neo's config APIs
 @EventBusSubscriber(modid = ExampleMod.MODID, bus = EventBusSubscriber.Bus.MOD)
 public class Config {
-    private static final ModConfigSpec.Builder BUILDER = new ModConfigSpec.Builder();
+  private static final ModConfigSpec.Builder BUILDER = new ModConfigSpec.Builder();
 
-    private static final ModConfigSpec.BooleanValue LOG_DIRT_BLOCK =
-            BUILDER.comment("Whether to log the dirt block on common setup")
-                    .define("logDirtBlock", true);
+  private static final ModConfigSpec.BooleanValue LOG_DIRT_BLOCK =
+      BUILDER.comment("Whether to log the dirt block on common setup").define("logDirtBlock", true);
 
-    private static final ModConfigSpec.IntValue MAGIC_NUMBER =
-            BUILDER.comment("A magic number")
-                    .defineInRange("magicNumber", 42, 0, Integer.MAX_VALUE);
+  private static final ModConfigSpec.IntValue MAGIC_NUMBER =
+      BUILDER.comment("A magic number").defineInRange("magicNumber", 42, 0, Integer.MAX_VALUE);
 
-    public static final ModConfigSpec.ConfigValue<String> MAGIC_NUMBER_INTRODUCTION =
-            BUILDER.comment("What you want the introduction message to be for the magic number")
-                    .define("magicNumberIntroduction", "The magic number is... ");
+  public static final ModConfigSpec.ConfigValue<String> MAGIC_NUMBER_INTRODUCTION =
+      BUILDER
+          .comment("What you want the introduction message to be for the magic number")
+          .define("magicNumberIntroduction", "The magic number is... ");
 
-    // a list of strings that are treated as resource locations for items
-    private static final ModConfigSpec.ConfigValue<List<? extends String>> ITEM_STRINGS =
-            BUILDER.comment("A list of items to log on common setup.")
-                    .defineListAllowEmpty(
-                            "items", List.of("minecraft:iron_ingot"), Config::validateItemName);
+  // a list of strings that are treated as resource locations for items
+  private static final ModConfigSpec.ConfigValue<List<? extends String>> ITEM_STRINGS =
+      BUILDER
+          .comment("A list of items to log on common setup.")
+          .defineListAllowEmpty("items", List.of("minecraft:iron_ingot"), Config::validateItemName);
 
-    static final ModConfigSpec SPEC = BUILDER.build();
+  static final ModConfigSpec SPEC = BUILDER.build();
 
-    public static boolean logDirtBlock;
-    public static int magicNumber;
-    public static String magicNumberIntroduction;
-    public static Set<Item> items;
+  public static boolean logDirtBlock;
+  public static int magicNumber;
+  public static String magicNumberIntroduction;
+  public static Set<Item> items;
 
-    private static boolean validateItemName(final Object obj) {
-        return obj instanceof String itemName
-                && BuiltInRegistries.ITEM.containsKey(ResourceLocation.parse(itemName));
-    }
+  private static boolean validateItemName(final Object obj) {
+    return obj instanceof String itemName
+        && BuiltInRegistries.ITEM.containsKey(ResourceLocation.parse(itemName));
+  }
 
-    @SubscribeEvent
-    static void onLoad(final ModConfigEvent event) {
-        logDirtBlock = LOG_DIRT_BLOCK.get();
-        magicNumber = MAGIC_NUMBER.get();
-        magicNumberIntroduction = MAGIC_NUMBER_INTRODUCTION.get();
+  @SubscribeEvent
+  static void onLoad(final ModConfigEvent event) {
+    logDirtBlock = LOG_DIRT_BLOCK.get();
+    magicNumber = MAGIC_NUMBER.get();
+    magicNumberIntroduction = MAGIC_NUMBER_INTRODUCTION.get();
 
-        // convert the list of strings into a set of items
-        items =
-                ITEM_STRINGS.get().stream()
-                        .map(
-                                itemName ->
-                                        BuiltInRegistries.ITEM.get(
-                                                ResourceLocation.parse(itemName)))
-                        .collect(Collectors.toSet());
-    }
+    // convert the list of strings into a set of items
+    items =
+        ITEM_STRINGS.get().stream()
+            .map(itemName -> BuiltInRegistries.ITEM.get(ResourceLocation.parse(itemName)))
+            .collect(Collectors.toSet());
+  }
 }

--- a/src/main/java/com/example/examplemod/ExampleMod.java
+++ b/src/main/java/com/example/examplemod/ExampleMod.java
@@ -1,9 +1,7 @@
+/* (C)2025 */
 package com.example.examplemod;
 
-import org.slf4j.Logger;
-
 import com.mojang.logging.LogUtils;
-
 import net.minecraft.client.Minecraft;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.core.registries.Registries;
@@ -33,44 +31,76 @@ import net.neoforged.neoforge.registries.DeferredBlock;
 import net.neoforged.neoforge.registries.DeferredHolder;
 import net.neoforged.neoforge.registries.DeferredItem;
 import net.neoforged.neoforge.registries.DeferredRegister;
+import org.slf4j.Logger;
 
 // The value here should match an entry in the META-INF/neoforge.mods.toml file
 @Mod(ExampleMod.MODID)
-public class ExampleMod
-{
+public class ExampleMod {
     // Define mod id in a common place for everything to reference
     public static final String MODID = "create_noise";
     // Directly reference a slf4j logger
     private static final Logger LOGGER = LogUtils.getLogger();
-    // Create a Deferred Register to hold Blocks which will all be registered under the "examplemod" namespace
+    // Create a Deferred Register to hold Blocks which will all be registered under the "examplemod"
+    // namespace
     public static final DeferredRegister.Blocks BLOCKS = DeferredRegister.createBlocks(MODID);
-    // Create a Deferred Register to hold Items which will all be registered under the "examplemod" namespace
+    // Create a Deferred Register to hold Items which will all be registered under the "examplemod"
+    // namespace
     public static final DeferredRegister.Items ITEMS = DeferredRegister.createItems(MODID);
-    // Create a Deferred Register to hold CreativeModeTabs which will all be registered under the "examplemod" namespace
-    public static final DeferredRegister<CreativeModeTab> CREATIVE_MODE_TABS = DeferredRegister.create(Registries.CREATIVE_MODE_TAB, MODID);
+    // Create a Deferred Register to hold CreativeModeTabs which will all be registered under the
+    // "examplemod" namespace
+    public static final DeferredRegister<CreativeModeTab> CREATIVE_MODE_TABS =
+            DeferredRegister.create(Registries.CREATIVE_MODE_TAB, MODID);
 
     // Creates a new Block with the id "examplemod:example_block", combining the namespace and path
-    public static final DeferredBlock<Block> EXAMPLE_BLOCK = BLOCKS.registerSimpleBlock("example_block", BlockBehaviour.Properties.of().mapColor(MapColor.STONE));
-    // Creates a new BlockItem with the id "examplemod:example_block", combining the namespace and path
-    public static final DeferredItem<BlockItem> EXAMPLE_BLOCK_ITEM = ITEMS.registerSimpleBlockItem("example_block", EXAMPLE_BLOCK);
+    public static final DeferredBlock<Block> EXAMPLE_BLOCK =
+            BLOCKS.registerSimpleBlock(
+                    "example_block", BlockBehaviour.Properties.of().mapColor(MapColor.STONE));
+    // Creates a new BlockItem with the id "examplemod:example_block", combining the namespace and
+    // path
+    public static final DeferredItem<BlockItem> EXAMPLE_BLOCK_ITEM =
+            ITEMS.registerSimpleBlockItem("example_block", EXAMPLE_BLOCK);
 
     // Creates a new food item with the id "examplemod:example_id", nutrition 1 and saturation 2
-    public static final DeferredItem<Item> EXAMPLE_ITEM = ITEMS.registerSimpleItem("example_item", new Item.Properties().food(new FoodProperties.Builder()
-            .alwaysEdible().nutrition(1).saturationModifier(2f).build()));
+    public static final DeferredItem<Item> EXAMPLE_ITEM =
+            ITEMS.registerSimpleItem(
+                    "example_item",
+                    new Item.Properties()
+                            .food(
+                                    new FoodProperties.Builder()
+                                            .alwaysEdible()
+                                            .nutrition(1)
+                                            .saturationModifier(2f)
+                                            .build()));
 
-    // Creates a creative tab with the id "examplemod:example_tab" for the example item, that is placed after the combat tab
-    public static final DeferredHolder<CreativeModeTab, CreativeModeTab> EXAMPLE_TAB = CREATIVE_MODE_TABS.register("example_tab", () -> CreativeModeTab.builder()
-            .title(Component.translatable("itemGroup.examplemod")) //The language key for the title of your CreativeModeTab
-            .withTabsBefore(CreativeModeTabs.COMBAT)
-            .icon(() -> EXAMPLE_ITEM.get().getDefaultInstance())
-            .displayItems((parameters, output) -> {
-                output.accept(EXAMPLE_ITEM.get()); // Add the example item to the tab. For your own tabs, this method is preferred over the event
-            }).build());
+    // Creates a creative tab with the id "examplemod:example_tab" for the example item, that is
+    // placed after the combat tab
+    public static final DeferredHolder<CreativeModeTab, CreativeModeTab> EXAMPLE_TAB =
+            CREATIVE_MODE_TABS.register(
+                    "example_tab",
+                    () ->
+                            CreativeModeTab.builder()
+                                    .title(
+                                            Component.translatable(
+                                                    "itemGroup.examplemod")) // The language key for
+                                    // the title of your
+                                    // CreativeModeTab
+                                    .withTabsBefore(CreativeModeTabs.COMBAT)
+                                    .icon(() -> EXAMPLE_ITEM.get().getDefaultInstance())
+                                    .displayItems(
+                                            (parameters, output) -> {
+                                                output.accept(
+                                                        EXAMPLE_ITEM
+                                                                .get()); // Add the example item to
+                                                // the tab. For your own
+                                                // tabs, this method is
+                                                // preferred over the event
+                                            })
+                                    .build());
 
     // The constructor for the mod class is the first code that is run when your mod is loaded.
-    // FML will recognize some parameter types like IEventBus or ModContainer and pass them in automatically.
-    public ExampleMod(IEventBus modEventBus, ModContainer modContainer)
-    {
+    // FML will recognize some parameter types like IEventBus or ModContainer and pass them in
+    // automatically.
+    public ExampleMod(IEventBus modEventBus, ModContainer modContainer) {
         // Register the commonSetup method for modloading
         modEventBus.addListener(this::commonSetup);
 
@@ -82,8 +112,10 @@ public class ExampleMod
         CREATIVE_MODE_TABS.register(modEventBus);
 
         // Register ourselves for server and other game events we are interested in.
-        // Note that this is necessary if and only if we want *this* class (ExampleMod) to respond directly to events.
-        // Do not add this line if there are no @SubscribeEvent-annotated functions in this class, like onServerStarting() below.
+        // Note that this is necessary if and only if we want *this* class (ExampleMod) to respond
+        // directly to events.
+        // Do not add this line if there are no @SubscribeEvent-annotated functions in this class,
+        // like onServerStarting() below.
         NeoForge.EVENT_BUS.register(this);
 
         // Register the item to a creative tab
@@ -93,8 +125,7 @@ public class ExampleMod
         modContainer.registerConfig(ModConfig.Type.COMMON, Config.SPEC);
     }
 
-    private void commonSetup(final FMLCommonSetupEvent event)
-    {
+    private void commonSetup(final FMLCommonSetupEvent event) {
         // Some common setup code
         LOGGER.info("HELLO FROM COMMON SETUP");
 
@@ -107,27 +138,23 @@ public class ExampleMod
     }
 
     // Add the example block item to the building blocks tab
-    private void addCreative(BuildCreativeModeTabContentsEvent event)
-    {
-        if (event.getTabKey() == CreativeModeTabs.BUILDING_BLOCKS)
-            event.accept(EXAMPLE_BLOCK_ITEM);
+    private void addCreative(BuildCreativeModeTabContentsEvent event) {
+        if (event.getTabKey() == CreativeModeTabs.BUILDING_BLOCKS) event.accept(EXAMPLE_BLOCK_ITEM);
     }
 
     // You can use SubscribeEvent and let the Event Bus discover methods to call
     @SubscribeEvent
-    public void onServerStarting(ServerStartingEvent event)
-    {
+    public void onServerStarting(ServerStartingEvent event) {
         // Do something when the server starts
         LOGGER.info("HELLO from server starting");
     }
 
-    // You can use EventBusSubscriber to automatically register all static methods in the class annotated with @SubscribeEvent
+    // You can use EventBusSubscriber to automatically register all static methods in the class
+    // annotated with @SubscribeEvent
     @EventBusSubscriber(modid = MODID, bus = EventBusSubscriber.Bus.MOD, value = Dist.CLIENT)
-    public static class ClientModEvents
-    {
+    public static class ClientModEvents {
         @SubscribeEvent
-        public static void onClientSetup(FMLClientSetupEvent event)
-        {
+        public static void onClientSetup(FMLClientSetupEvent event) {
             // Some client setup code
             LOGGER.info("HELLO FROM CLIENT SETUP");
             LOGGER.info("MINECRAFT NAME >> {}", Minecraft.getInstance().getUser().getName());

--- a/src/main/java/com/example/examplemod/ExampleMod.java
+++ b/src/main/java/com/example/examplemod/ExampleMod.java
@@ -36,128 +36,124 @@ import org.slf4j.Logger;
 // The value here should match an entry in the META-INF/neoforge.mods.toml file
 @Mod(ExampleMod.MODID)
 public class ExampleMod {
-    // Define mod id in a common place for everything to reference
-    public static final String MODID = "create_noise";
-    // Directly reference a slf4j logger
-    private static final Logger LOGGER = LogUtils.getLogger();
-    // Create a Deferred Register to hold Blocks which will all be registered under the "examplemod"
-    // namespace
-    public static final DeferredRegister.Blocks BLOCKS = DeferredRegister.createBlocks(MODID);
-    // Create a Deferred Register to hold Items which will all be registered under the "examplemod"
-    // namespace
-    public static final DeferredRegister.Items ITEMS = DeferredRegister.createItems(MODID);
-    // Create a Deferred Register to hold CreativeModeTabs which will all be registered under the
-    // "examplemod" namespace
-    public static final DeferredRegister<CreativeModeTab> CREATIVE_MODE_TABS =
-            DeferredRegister.create(Registries.CREATIVE_MODE_TAB, MODID);
+  // Define mod id in a common place for everything to reference
+  public static final String MODID = "create_noise";
+  // Directly reference a slf4j logger
+  private static final Logger LOGGER = LogUtils.getLogger();
+  // Create a Deferred Register to hold Blocks which will all be registered under the "examplemod"
+  // namespace
+  public static final DeferredRegister.Blocks BLOCKS = DeferredRegister.createBlocks(MODID);
+  // Create a Deferred Register to hold Items which will all be registered under the "examplemod"
+  // namespace
+  public static final DeferredRegister.Items ITEMS = DeferredRegister.createItems(MODID);
+  // Create a Deferred Register to hold CreativeModeTabs which will all be registered under the
+  // "examplemod" namespace
+  public static final DeferredRegister<CreativeModeTab> CREATIVE_MODE_TABS =
+      DeferredRegister.create(Registries.CREATIVE_MODE_TAB, MODID);
 
-    // Creates a new Block with the id "examplemod:example_block", combining the namespace and path
-    public static final DeferredBlock<Block> EXAMPLE_BLOCK =
-            BLOCKS.registerSimpleBlock(
-                    "example_block", BlockBehaviour.Properties.of().mapColor(MapColor.STONE));
-    // Creates a new BlockItem with the id "examplemod:example_block", combining the namespace and
-    // path
-    public static final DeferredItem<BlockItem> EXAMPLE_BLOCK_ITEM =
-            ITEMS.registerSimpleBlockItem("example_block", EXAMPLE_BLOCK);
+  // Creates a new Block with the id "examplemod:example_block", combining the namespace and path
+  public static final DeferredBlock<Block> EXAMPLE_BLOCK =
+      BLOCKS.registerSimpleBlock(
+          "example_block", BlockBehaviour.Properties.of().mapColor(MapColor.STONE));
+  // Creates a new BlockItem with the id "examplemod:example_block", combining the namespace and
+  // path
+  public static final DeferredItem<BlockItem> EXAMPLE_BLOCK_ITEM =
+      ITEMS.registerSimpleBlockItem("example_block", EXAMPLE_BLOCK);
 
-    // Creates a new food item with the id "examplemod:example_id", nutrition 1 and saturation 2
-    public static final DeferredItem<Item> EXAMPLE_ITEM =
-            ITEMS.registerSimpleItem(
-                    "example_item",
-                    new Item.Properties()
-                            .food(
-                                    new FoodProperties.Builder()
-                                            .alwaysEdible()
-                                            .nutrition(1)
-                                            .saturationModifier(2f)
-                                            .build()));
+  // Creates a new food item with the id "examplemod:example_id", nutrition 1 and saturation 2
+  public static final DeferredItem<Item> EXAMPLE_ITEM =
+      ITEMS.registerSimpleItem(
+          "example_item",
+          new Item.Properties()
+              .food(
+                  new FoodProperties.Builder()
+                      .alwaysEdible()
+                      .nutrition(1)
+                      .saturationModifier(2f)
+                      .build()));
 
-    // Creates a creative tab with the id "examplemod:example_tab" for the example item, that is
-    // placed after the combat tab
-    public static final DeferredHolder<CreativeModeTab, CreativeModeTab> EXAMPLE_TAB =
-            CREATIVE_MODE_TABS.register(
-                    "example_tab",
-                    () ->
-                            CreativeModeTab.builder()
-                                    .title(
-                                            Component.translatable(
-                                                    "itemGroup.examplemod")) // The language key for
-                                    // the title of your
-                                    // CreativeModeTab
-                                    .withTabsBefore(CreativeModeTabs.COMBAT)
-                                    .icon(() -> EXAMPLE_ITEM.get().getDefaultInstance())
-                                    .displayItems(
-                                            (parameters, output) -> {
-                                                output.accept(
-                                                        EXAMPLE_ITEM
-                                                                .get()); // Add the example item to
-                                                // the tab. For your own
-                                                // tabs, this method is
-                                                // preferred over the event
-                                            })
-                                    .build());
+  // Creates a creative tab with the id "examplemod:example_tab" for the example item, that is
+  // placed after the combat tab
+  public static final DeferredHolder<CreativeModeTab, CreativeModeTab> EXAMPLE_TAB =
+      CREATIVE_MODE_TABS.register(
+          "example_tab",
+          () ->
+              CreativeModeTab.builder()
+                  .title(Component.translatable("itemGroup.examplemod")) // The language key for
+                  // the title of your
+                  // CreativeModeTab
+                  .withTabsBefore(CreativeModeTabs.COMBAT)
+                  .icon(() -> EXAMPLE_ITEM.get().getDefaultInstance())
+                  .displayItems(
+                      (parameters, output) -> {
+                        output.accept(EXAMPLE_ITEM.get()); // Add the example item to
+                        // the tab. For your own
+                        // tabs, this method is
+                        // preferred over the event
+                      })
+                  .build());
 
-    // The constructor for the mod class is the first code that is run when your mod is loaded.
-    // FML will recognize some parameter types like IEventBus or ModContainer and pass them in
-    // automatically.
-    public ExampleMod(IEventBus modEventBus, ModContainer modContainer) {
-        // Register the commonSetup method for modloading
-        modEventBus.addListener(this::commonSetup);
+  // The constructor for the mod class is the first code that is run when your mod is loaded.
+  // FML will recognize some parameter types like IEventBus or ModContainer and pass them in
+  // automatically.
+  public ExampleMod(IEventBus modEventBus, ModContainer modContainer) {
+    // Register the commonSetup method for modloading
+    modEventBus.addListener(this::commonSetup);
 
-        // Register the Deferred Register to the mod event bus so blocks get registered
-        BLOCKS.register(modEventBus);
-        // Register the Deferred Register to the mod event bus so items get registered
-        ITEMS.register(modEventBus);
-        // Register the Deferred Register to the mod event bus so tabs get registered
-        CREATIVE_MODE_TABS.register(modEventBus);
+    // Register the Deferred Register to the mod event bus so blocks get registered
+    BLOCKS.register(modEventBus);
+    // Register the Deferred Register to the mod event bus so items get registered
+    ITEMS.register(modEventBus);
+    // Register the Deferred Register to the mod event bus so tabs get registered
+    CREATIVE_MODE_TABS.register(modEventBus);
 
-        // Register ourselves for server and other game events we are interested in.
-        // Note that this is necessary if and only if we want *this* class (ExampleMod) to respond
-        // directly to events.
-        // Do not add this line if there are no @SubscribeEvent-annotated functions in this class,
-        // like onServerStarting() below.
-        NeoForge.EVENT_BUS.register(this);
+    // Register ourselves for server and other game events we are interested in.
+    // Note that this is necessary if and only if we want *this* class (ExampleMod) to respond
+    // directly to events.
+    // Do not add this line if there are no @SubscribeEvent-annotated functions in this class,
+    // like onServerStarting() below.
+    NeoForge.EVENT_BUS.register(this);
 
-        // Register the item to a creative tab
-        modEventBus.addListener(this::addCreative);
+    // Register the item to a creative tab
+    modEventBus.addListener(this::addCreative);
 
-        // Register our mod's ModConfigSpec so that FML can create and load the config file for us
-        modContainer.registerConfig(ModConfig.Type.COMMON, Config.SPEC);
-    }
+    // Register our mod's ModConfigSpec so that FML can create and load the config file for us
+    modContainer.registerConfig(ModConfig.Type.COMMON, Config.SPEC);
+  }
 
-    private void commonSetup(final FMLCommonSetupEvent event) {
-        // Some common setup code
-        LOGGER.info("HELLO FROM COMMON SETUP");
+  private void commonSetup(final FMLCommonSetupEvent event) {
+    // Some common setup code
+    LOGGER.info("HELLO FROM COMMON SETUP");
 
-        if (Config.logDirtBlock)
-            LOGGER.info("DIRT BLOCK >> {}", BuiltInRegistries.BLOCK.getKey(Blocks.DIRT));
+    if (Config.logDirtBlock)
+      LOGGER.info("DIRT BLOCK >> {}", BuiltInRegistries.BLOCK.getKey(Blocks.DIRT));
 
-        LOGGER.info(Config.magicNumberIntroduction + Config.magicNumber);
+    LOGGER.info(Config.magicNumberIntroduction + Config.magicNumber);
 
-        Config.items.forEach((item) -> LOGGER.info("ITEM >> {}", item.toString()));
-    }
+    Config.items.forEach((item) -> LOGGER.info("ITEM >> {}", item.toString()));
+  }
 
-    // Add the example block item to the building blocks tab
-    private void addCreative(BuildCreativeModeTabContentsEvent event) {
-        if (event.getTabKey() == CreativeModeTabs.BUILDING_BLOCKS) event.accept(EXAMPLE_BLOCK_ITEM);
-    }
+  // Add the example block item to the building blocks tab
+  private void addCreative(BuildCreativeModeTabContentsEvent event) {
+    if (event.getTabKey() == CreativeModeTabs.BUILDING_BLOCKS) event.accept(EXAMPLE_BLOCK_ITEM);
+  }
 
-    // You can use SubscribeEvent and let the Event Bus discover methods to call
+  // You can use SubscribeEvent and let the Event Bus discover methods to call
+  @SubscribeEvent
+  public void onServerStarting(ServerStartingEvent event) {
+    // Do something when the server starts
+    LOGGER.info("HELLO from server starting");
+  }
+
+  // You can use EventBusSubscriber to automatically register all static methods in the class
+  // annotated with @SubscribeEvent
+  @EventBusSubscriber(modid = MODID, bus = EventBusSubscriber.Bus.MOD, value = Dist.CLIENT)
+  public static class ClientModEvents {
     @SubscribeEvent
-    public void onServerStarting(ServerStartingEvent event) {
-        // Do something when the server starts
-        LOGGER.info("HELLO from server starting");
+    public static void onClientSetup(FMLClientSetupEvent event) {
+      // Some client setup code
+      LOGGER.info("HELLO FROM CLIENT SETUP");
+      LOGGER.info("MINECRAFT NAME >> {}", Minecraft.getInstance().getUser().getName());
     }
-
-    // You can use EventBusSubscriber to automatically register all static methods in the class
-    // annotated with @SubscribeEvent
-    @EventBusSubscriber(modid = MODID, bus = EventBusSubscriber.Bus.MOD, value = Dist.CLIENT)
-    public static class ClientModEvents {
-        @SubscribeEvent
-        public static void onClientSetup(FMLClientSetupEvent event) {
-            // Some client setup code
-            LOGGER.info("HELLO FROM CLIENT SETUP");
-            LOGGER.info("MINECRAFT NAME >> {}", Minecraft.getInstance().getUser().getName());
-        }
-    }
+  }
 }


### PR DESCRIPTION
We can change the formatting, but this is a starter configuration

Adds the following gradle tasks (it adds more, but these are the ones of interest)
- SpotlessCheck
- SpotlessApply

Applies formatting so we can see how it may look when we start putting our own things here.

No changes are needed for CI to fail when changes break formatting rules.